### PR TITLE
Workaround for CDDLive timers which require parameters passed in the timer callback.

### DIFF
--- a/source/Comm/NetworkPort.cpp
+++ b/source/Comm/NetworkPort.cpp
@@ -16,8 +16,9 @@
 extern "C" {
 //#include "gpio_pins.h"
 //#include "uart_voice.h"
-//#include "timekeeper.h"
 }
+
+#include "timekeeper.h"
 
 #include <stdio.h>
 
@@ -115,7 +116,7 @@ void NetworkPort::ConfigureMeters(int nAutoMetersListId, int nAutoMetersRate, in
 	{
 		_time_init_ticks(&m_SubscriptionTicks[nList], 0);
 		_time_add_msec_to_ticks(&m_SubscriptionTicks[nList], m_nAutoMetersRate[nList]);
-//		m_SubscriptionTimer[nList] = _timer_start_periodic_every_ticks(NetworkSubscriptionUpdater, m_SubscriptionTimer, TIMER_ELAPSED_TIME_MODE, &m_SubscriptionTicks[nList]);
+		m_SubscriptionTimer[nList] = _timer_start_periodic_every_ticks(NetworkSubscriptionUpdater, m_SubscriptionTimer, TIMER_ELAPSED_TIME_MODE, &m_SubscriptionTicks[nList]);
 	}
 }
 #endif	//	_SECONDARY_BOOT

--- a/source/Comm/UartPort.cpp
+++ b/source/Comm/UartPort.cpp
@@ -14,8 +14,9 @@
 extern "C" {
 //#include "gpio_pins.h"
 //#include "uart_voice.h"
-//#include "timekeeper.h"
 }
+
+#include "timekeeper.h"
 
 extern mandolin_fifo UartVoiceRxFifo;
 
@@ -61,7 +62,7 @@ void UartPort::ConfigureMeters(int nAutoMetersListId, int nAutoMetersRate, int n
 	{
 		_time_init_ticks(&m_SubscriptionTicks[nList], 0);
 		_time_add_msec_to_ticks(&m_SubscriptionTicks[nList], m_nAutoMetersRate[nList]);
-//		m_SubscriptionTimer[nList] = _timer_start_periodic_every_ticks(VoicingSubscriptionUpdater, m_SubscriptionTimer, TIMER_ELAPSED_TIME_MODE, &m_SubscriptionTicks[nList]);
+		m_SubscriptionTimer[nList] = _timer_start_periodic_every_ticks(VoicingSubscriptionUpdater, m_SubscriptionTimer, TIMER_ELAPSED_TIME_MODE, &m_SubscriptionTicks[nList]);
 	}
 }
 #endif	//	_SECONDARY_BOOT

--- a/source/MQX_To_FreeRTOS.h
+++ b/source/MQX_To_FreeRTOS.h
@@ -52,7 +52,7 @@ typedef QueueHandle_t _queue_id;          /* What a queue_id looks like */
 //   0 (failure)
 _pool_id _msgpool_create(uint16_t message_size, uint16_t num_messages, uint16_t grow_number, uint16_t grow_limit);
 
-// pool_id [IN] ï¿½ A pool ID from _msgpool_create()
+// pool_id [IN] ? A pool ID from _msgpool_create()
 // Returns  Pointer to a message (success)
 //          NULL (failure)
 void *_msg_alloc(_pool_id pool_id);
@@ -121,19 +121,19 @@ typedef struct message_header_struct
 } MESSAGE_HEADER_STRUCT, * MESSAGE_HEADER_STRUCT_PTR;
 
 
-// processor_number [IN] ï¿½ One of the following:
+// processor_number [IN] ? One of the following:
 //          processor on which the message queue resides
 //          0 (indicates the local processor)
-// queue_number [IN] ï¿½ Image-wide unique number that identifies the message queue
+// queue_number [IN] ? Image-wide unique number that identifies the message queue
 // Returns  Queue ID for the queue (success)
 //          MSGQ_NULL_QUEUE_ID (failure: _processor_number is not valid)
 _queue_id _msgq_get_id(_processor_number processor_number, _queue_number queue_number);
 
-// queue_number [IN] ï¿½ One of the following:
+// queue_number [IN] ? One of the following:
 //          queue number of the message queue to be opened on this processor (min. 8, max. as defined in
 //          the MQX RTOS initialization structure)
 //          MSGQ_FREE_QUEUE (MQX RTOS opens an unopened message queue)
-// max_queue_size [IN] ï¿½ One of the following:
+// max_queue_size [IN] ? One of the following:
 //          maximum queue size
 //          0 (unlimited size)
 // Returns  Queue ID (success)
@@ -147,23 +147,23 @@ void *_msgq_poll( _queue_id queue_id );
 
 // queue_id [IN] 	Private message queue from which to receive a message
 //                  >>>> NOTE : New addition to prototype, therefore code changes required. <<<<
-// msg_ptr IN] ï¿½ Pointer to the message to be sent
+// msg_ptr IN] ? Pointer to the message to be sent
 // Returns  TRUE (success: see description)
 //          FALSE (failure)
 bool _msgq_send(_queue_id queue_id, void *msg_ptr);
 // ORIGINAL Prototype : bool _msgq_send(void *msg_ptr);
 
-// queue_id [IN] ï¿½ One of the following:
+// queue_id [IN] ? One of the following:
 //                  private message queue from which to receive a message
 //                  MSGQ_ANY_QUEUE (any queue that the task owns)
-// ms_timeout [IN] ï¿½ One of the following:
+// ms_timeout [IN] ? One of the following:
 //                  maximum number of milliseconds to wait. After the timeout elapses without the message, the function returns.
 //                  0 (unlimited wait)
 // Returns      Pointer to a message (success)
 //              NULL (failure)
 void*_msgq_receive(_queue_id queue_id, uint32_t ms_timeout);
 
-// queue_id [IN] — One of the following:
+// queue_id [IN] ? One of the following:
 // 			queue ID of the queue to be checked
 //			MSGQ_ANY_QUEUE (get the number of messages waiting in all message queues that the task has open)
 // Returns
@@ -261,6 +261,7 @@ typedef struct mqx_tick_struct
 typedef void (* TIMER_NOTIFICATION_TICK_FPTR)( _timer_id );
 
 _timer_id  _timer_start_periodic_every_ticks(TIMER_NOTIFICATION_TICK_FPTR, void *, _mqx_uint, MQX_TICK_STRUCT_PTR);
+bool retrieveNotificationParams( TIMER_NOTIFICATION_TICK_FPTR notification_function, uint32_t **notification_data_ptr );
 _mqx_uint  _timer_cancel(_timer_id);
 _timer_id  _timer_start_oneshot_after_ticks(TIMER_NOTIFICATION_TICK_FPTR, void *, _mqx_uint, MQX_TICK_STRUCT_PTR);
 

--- a/source/TimeKeeper.cpp
+++ b/source/TimeKeeper.cpp
@@ -67,16 +67,23 @@ void TriggerFlashWrite( _timer_id id)
 	_lwevent_set( &timer_event, event_timer_flashwrite_expired );
 }
 
-
-void NetworkSubscriptionUpdater( _timer_id id, void * data_ptr, MQX_TICK_STRUCT_PTR tick_ptr )
-{
+#ifdef FREERTOS_CONFIG_H
+	void NetworkSubscriptionUpdater( _timer_id id )
+#else
+    void NetworkSubscriptionUpdater( _timer_id id, void * data_ptr, MQX_TICK_STRUCT_PTR tick_ptr )
+#endif
+{       
 	//	eventually needs to be multi-port, now just multi-list
-
 	uint32_t tmpID = *(uint32_t*)&id;
-	uint32_t * pSubsciptionArray = (uint32_t*)data_ptr;
+	uint32_t * pSubsciptionArray = NULL;
 	uint8_t ix;
-
 	int nLists = 2;
+	
+	// Look up parameter information based on timer ID (Workaround for differences between MQX and FreeRTOS timer callback prototypes)
+    if (retrieveNotificationParams(NetworkSubscriptionUpdater, &pSubsciptionArray) == false)
+    {
+        return; //Can't retrieve params for this callback so skip.
+    }
 
 	// Check which subscription timer ID has expired //
 	for(ix=0; ix<nLists; ix++) {
@@ -87,14 +94,22 @@ void NetworkSubscriptionUpdater( _timer_id id, void * data_ptr, MQX_TICK_STRUCT_
 	_lwevent_set( &timer_event, event_timer_subscription_Network1<<ix );
 }
 
-void VoicingSubscriptionUpdater( _timer_id id, void * data_ptr, MQX_TICK_STRUCT_PTR tick_ptr )
+#ifdef FREERTOS_CONFIG_H
+	void VoicingSubscriptionUpdater( _timer_id id )
+#else
+    void VoicingSubscriptionUpdater( _timer_id id, void * data_ptr, MQX_TICK_STRUCT_PTR tick_ptr )
+#endif
 {
-
 	uint32_t tmpID = *(uint32_t*)&id;
-	uint32_t * pSubsciptionArray = (uint32_t*)data_ptr;
+	uint32_t * pSubsciptionArray = NULL;
 	uint8_t ix;
-
 	int nLists = 2;
+	
+	// Look up parameter information based on timer ID (Workaround for differences between MQX and FreeRTOS timer callback prototypes)
+    if (retrieveNotificationParams(VoicingSubscriptionUpdater, &pSubsciptionArray) == false)
+    {
+        return; //Can't retrieve params for this callback so skip.
+    }
 
 	// Check which subscription timer ID has expired //
 	for(ix=0; ix<nLists; ix++) {

--- a/source/TimeKeeper.h
+++ b/source/TimeKeeper.h
@@ -37,12 +37,15 @@ void DeferredReboot(int nMs);
 void HeartbeatTimer( _timer_id id);
 void CheckAmps( _timer_id id);
 void TriggerFlashWrite( _timer_id id);
-void NetworkSubscriptionUpdater( _timer_id id, void * data_ptr, MQX_TICK_STRUCT_PTR tick_ptr );
-void VoicingSubscriptionUpdater( _timer_id id, void * data_ptr, MQX_TICK_STRUCT_PTR tick_ptr );
+
 #ifdef FREERTOS_CONFIG_H
+    void NetworkSubscriptionUpdater( _timer_id id );
+    void VoicingSubscriptionUpdater( _timer_id id );
 	void TriggerSelfTestSwitch( _timer_id id );
 #else
-	void TriggerSelfTestSwitch( _timer_id id);
+    void NetworkSubscriptionUpdater( _timer_id id, void * data_ptr, MQX_TICK_STRUCT_PTR tick_ptr );
+    void VoicingSubscriptionUpdater( _timer_id id, void * data_ptr, MQX_TICK_STRUCT_PTR tick_ptr );
+	void TriggerSelfTestSwitch( _timer_id id, void * data_ptr, MQX_TICK_STRUCT_PTR tick_ptr );
 #endif
 void UIBackToDefaultScreen( _timer_id id);
 


### PR DESCRIPTION
This is due to the differences in timer callback prototypes between MQX and FreeRTOS. Fix is specific for CDDLive needs.