### PR TITLE
Deal with Ethernet cable disconnections by monitoring Dante link stat…

### DIFF
--- a/CDDLive/source/ConfigManager.cpp
+++ b/CDDLive/source/ConfigManager.cpp
@@ -2921,6 +2921,18 @@ void Config::OpenNetworkPort(bool bOpen, int nPort)
     	}
     	olyUI.UpdateStatusLine4(tempString);
     #endif
+
+    	if ( m_bDanteRebooting )
+    	{	// linkFlag state during Dante reboot does not signify cable disconnection, so ignore
+//    		printf("DANTE REBOOTING : LFlags=%X, Mute=%X\n", linkFlags, DanteMute );
+    		if ( linkFlags & 0x001 )
+    			m_bDanteRebooting = false;
+    	}
+    	else if ( (linkFlags & 0x001) == 0 )
+    	{	// Cable Disconnected : Use this as a general cable disconnect indication to force close any Network connections.
+    		printf("CABLE DISCONNECTED : Tidy Up Connections\n");
+    		olyNetworkPort.SetForceClose();
+    	}
     }
     
     void Config::OnDanteChange_MacAddress(uint8_t * macAddress)
@@ -3108,6 +3120,7 @@ void Config::OpenNetworkPort(bool bOpen, int nPort)
     		}
     	}
     #endif
+    	m_bDanteRebooting = true;
     }
     
     void Config::OnDanteChange_Upgrade(void)

--- a/CDDLive/source/ConfigManager.h
+++ b/CDDLive/source/ConfigManager.h
@@ -101,6 +101,7 @@ protected:
 	bool			previous_lf_test_value = false;
 	bool			previous_lf_mute_value = false;
 	bool			previous_lf_solo_value = false;
+	bool			m_bDanteRebooting = false;
 
 #ifdef	USE_DANTE_AUTO_STATIC_IP
 	bool 			m_bdante_auto_ip_address_changed = false;


### PR DESCRIPTION
Deal with Ethernet cable disconnections by monitoring Dante link status to perform the network connection cleanup.
Note that all MDIO communications with PHY were not working, I think due to hardware design (shared switch connection with Ethernet/Dante), therefore I've used the alternative
solution of monitoring the Dante link status.